### PR TITLE
refactor: remove premium user functionality and related code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   - Comandos intuitivos y mensajes de progreso para una mejor experiencia de usuario.
   - Mensajes de ayuda detallados.
 - **Gestión de Usuarios**:
-  - Distinción entre usuarios normales, premium y administradores con permisos específicos.
+  - Distinción entre usuarios normales y administradores con permisos específicos.
 - **Persistencia de Datos**:
   - Almacena mensajes y configuraciones en una base de datos SQLite para un funcionamiento eficiente.
 

--- a/bot/commands/help_command.py
+++ b/bot/commands/help_command.py
@@ -36,7 +36,6 @@ HELP_MESSAGE = (
     "• **Encuestas:** Resumen de preguntas y opciones de encuestas enviadas en el chat.\n\n"
     "🔹 **Características Adicionales:**\n"
     "• **Almacenamiento de Mensajes:** Todos los mensajes enviados en el chat se almacenan en la base de datos para facilitar la generación de resúmenes precisos.\n"
-    "• **Usuarios Premium:** Acceso exclusivo a funcionalidades avanzadas como resúmenes más detallados y mayor capacidad de procesamiento.\n"
     "• **Administradores:** Comandos especiales y permisos adicionales para usuarios administradores.\n\n"
     "🔹 **Notas Importantes:**\n"
     "• **Seguridad y Privacidad:** El bot maneja información sensible. Asegúrate de que solo usuarios autorizados tengan acceso a comandos privilegiados.\n"

--- a/bot/commands/summarize_command.py
+++ b/bot/commands/summarize_command.py
@@ -5,7 +5,6 @@ from bot.utils.decorators import (
     log_command,
     bot_started,
     cooldown,
-    premium_only,
 )
 from bot.utils.format_utils import format_recent_messages, send_long_message
 from bot.utils.logger import logger
@@ -62,7 +61,6 @@ async def update_progress(message, text: str, delay: float = 0.5) -> None:
 
 
 @admin_command()
-@premium_only()
 @log_command()
 @bot_started()
 @cooldown(60)

--- a/bot/utils/decorators.py
+++ b/bot/utils/decorators.py
@@ -106,28 +106,6 @@ def cooldown(seconds: int):
     return decorator
 
 
-def premium_only():
-    """
-    Decorator to restrict command access to premium users only
-    """
-
-    def decorator(func):
-        @wraps(func)
-        async def wrapped(update: Update, context: ContextTypes.DEFAULT_TYPE):
-            user_id = update.effective_user.id
-            is_premium = await db_service.is_premium_user(user_id)
-            if not is_premium:
-                await update.message.reply_text(
-                    "Este comando es solo para usuarios premium!"
-                )
-                return
-            return await func(update, context)
-
-        return wrapped
-
-    return decorator
-
-
 def log_command():
     """
     Decorator to log command usage with extended user information

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -23,13 +23,13 @@ Dado que esta es la primera interacción con el proyecto "Al-Grano Bot" y mi mem
 
 - **Idioma de la Documentación**: Se utilizará español de España, según la solicitud del usuario.
 - **Nivel de Detalle**: Se buscará un equilibrio entre ser exhaustivo y conciso en la documentación para que sea útil sin ser abrumadora.
-- **Interpretación del Código**: Se interpretará la funcionalidad y el propósito del código tal como está escrito. Si hay ambigüedades o funcionalidades no implementadas explícitamente pero insinuadas (p.ej., "usuarios premium"), se señalarán.
+- **Interpretación del Código**: Se interpretará la funcionalidad y el propósito del código tal como está escrito. Si hay ambigüedades o funcionalidades no implementadas explícitamente pero insinuadas, se señalarán.
 
 ## 5. Patrones y Preferencias Importantes (Observados Inicialmente)
 
 - **Modularidad**: El código está organizado en carpetas (commands, handlers, services, utils), lo que sugiere una preferencia por la separación de responsabilidades.
 - **Singletons para Servicios**: Servicios como `DatabaseService`, `OpenAIService`, `TelegramBot`, `Config`, `Logger`, `MessageService`, `SchedulerService` se implementan como singletons, asegurando una única instancia.
-- **Decoradores**: Uso extensivo de decoradores para funcionalidades transversales como logging (`@log_command`), control de acceso (`@admin_command`, `@premium_only`), verificación de estado (`@bot_started`), y gestión de cooldowns (`@cooldown`).
+- **Decoradores**: Uso extensivo de decoradores para funcionalidades transversales como logging (`@log_command`), control de acceso (`@admin_command`), verificación de estado (`@bot_started`), y gestión de cooldowns (`@cooldown`).
 - **Manejo Asíncrono**: El bot utiliza `asyncio` y `async/await` para operaciones de E/S y concurrencia, crucial para un bot de Telegram.
 - **Configuración Externalizada**: Uso de variables de entorno (`.env` file, gestionado por `python-dotenv` y la clase `Config`) para configuraciones sensibles y específicas del entorno.
 - **Logging Detallado**: Implementación de un servicio de logging robusto que registra información en consola y archivos, con diferentes niveles de severidad.
@@ -44,4 +44,3 @@ Dado que esta es la primera interacción con el proyecto "Al-Grano Bot" y mi mem
 - La gestión de la API de OpenAI (resúmenes, transcripciones, análisis de imágenes) es central para el bot.
 - La persistencia de mensajes es clave para los resúmenes de chat y los resúmenes diarios.
 - El sistema de resúmenes diarios depende de un programador de tareas (`APScheduler`).
-- La funcionalidad de "usuarios premium" está presente a nivel de decorador, pero la lógica de negocio para definir o gestionar qué hace a un usuario "premium" (más allá del flag en la BD) no está completamente detallada en el código provisto.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -40,7 +40,7 @@ Basado en el análisis del código proporcionado, las siguientes funcionalidades
   - El tipo de resumen se almacena en `telegram_chat_state` y se usa tanto para `/summarize` (chat reciente) como para resúmenes diarios.
 - **Manejo de Usuarios y Permisos**:
   - Creación y actualización de usuarios en la BD (`get_or_create_user`).
-  - Decoradores `@admin_command` y `@premium_only` para restringir el acceso a comandos.
+  - Decorador `@admin_command` para restringir el acceso a comandos.
   - Los administradores pueden ser definidos en la BD (campo `is_admin`).
 - **Utilidades y Soporte**:
   - Sistema de logging robusto (`Logger`).
@@ -50,13 +50,10 @@ Basado en el análisis del código proporcionado, las siguientes funcionalidades
 
 ## 2. Qué Queda por Construir (o Mejorar)
 
-- **Gestión de Usuarios Premium Completa**:
-  - Actualmente, `@premium_only` restringe el acceso, pero no hay una lógica visible sobre cómo un usuario se _convierte_ en premium (ej. sistema de pago, comando de admin para otorgarlo).
-  - Las "funcionalidades avanzadas como resúmenes más detallados y mayor capacidad de procesamiento" mencionadas en el mensaje de `/help` para premium no están explícitamente implementadas de forma diferenciada más allá del acceso. El tipo de resumen (largo/corto) es global por chat, no por usuario.
 - **Comando `/about`**: Mencionado en `/help` pero no hay un handler implementado para él en el código proporcionado.
 - **Traducción y Localización**: Los prompts de OpenAI están codificados en español. Si se deseara soportar múltiples idiomas, se necesitaría un sistema de internacionalización (i18n).
 - **Pruebas Unitarias y de Integración**: No hay archivos de prueba visibles en el código, lo cual es crucial para la mantenibilidad.
-- **Interfaz de Administración Más Completa**: Más allá de los comandos individuales, podría haber una interfaz (ej. web o más comandos de bot) para gestionar usuarios (admins, premium), ver estadísticas, etc.
+- **Interfaz de Administración Más Completa**: Más allá de los comandos individuales, podría haber una interfaz (ej. web o más comandos de bot) para gestionar usuarios (admins), ver estadísticas, etc.
 - **Optimización de Costos de OpenAI**: Aunque se usa GPT-4o-mini para chunks de documentos grandes, un análisis continuo de costos y estrategias de prompting podría ser beneficioso.
 - **Manejo de Límites de Frecuencia de Telegram más Sofisticado**: El cooldown es por comando; Telegram tiene límites más complejos a nivel de bot.
 - **Escalabilidad de la Base de Datos**: SQLite es adecuado para muchos casos, pero para un uso muy intensivo o distribuido, se podría considerar una solución de BD diferente (ej. PostgreSQL).

--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -18,7 +18,7 @@
   - Resumir encuestas.
 - **Resúmenes Diarios Automáticos**: Ofrecer la opción de recibir un resumen diario automático de la actividad del chat.
 - **Personalización de Resúmenes**: Permitir a los usuarios elegir entre formatos de resumen largos (detallados) y cortos (concisos).
-- **Gestión de Usuarios**: Distinguir entre usuarios normales, usuarios premium y administradores, con diferentes niveles de acceso a funcionalidades.
+- **Gestión de Usuarios**: Distinguir entre usuarios normales y administradores, con diferentes niveles de acceso a funcionalidades.
 - **Interfaz Intuitiva**: Proporcionar una experiencia de usuario clara y fácil de usar a través de comandos de Telegram.
 - **Persistencia de Datos**: Almacenar mensajes y estados de chat para facilitar la generación de resúmenes y la configuración del bot.
 
@@ -35,8 +35,9 @@
   - API de OpenAI para transcripción de audio, análisis de imágenes y generación de resúmenes.
   - Librerías para procesar archivos (PDF, DOCX), extraer contenido de artículos web y transcripciones de YouTube.
 - **Administración**:
+
   - Comandos restringidos a administradores.
-  - Posibilidad de definir usuarios premium con acceso a funcionalidades mejoradas (aunque la lógica específica de "premium" está presente en decoradores, su implementación completa más allá del acceso no está detallada en el código).
+
 - **Persistencia**:
   - Base de datos SQLite para almacenar usuarios, mensajes, y estados de chat.
 

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -35,7 +35,7 @@ El "Al-Grano Bot" sigue una arquitectura modular común en aplicaciones de bots,
 
 - **Singleton**: Varios servicios (`DatabaseService`, `OpenAIService`, `TelegramBot`, `Config`, `Logger`, `MessageService`, `SchedulerService`) se implementan utilizando el patrón Singleton. Esto asegura que solo exista una instancia de estos servicios en toda la aplicación.
 - **Command**: La estructura de `python-telegram-bot` con `CommandHandler` y `MessageHandler` sigue inherentemente el patrón Command, donde cada comando o tipo de mensaje se encapsula como un objeto (el handler) que conoce cómo ejecutar la acción asociada.
-- **Decorator**: Utilizado بكثرة (`@log_command`, `@admin_command`, `@premium_only`, `@bot_started`, `@cooldown`) para añadir funcionalidades transversales a las funciones de comando de manera declarativa y no intrusiva.
+- **Decorator**: Utilizado بكثرة (`@log_command`, `@admin_command`, `@bot_started`, `@cooldown`) para añadir funcionalidades transversales a las funciones de comando de manera declarativa y no intrusiva.
 - **Strategy (Implícito)**:
   - En `summarize_command.py`, la lógica para manejar diferentes tipos de mensajes (`message_type` con `match/case`) puede verse como una forma de Strategy, donde se elige un algoritmo (handler específico) diferente según el tipo de mensaje.
   - En `OpenAIService`, los `SUMMARY_PROMPTS` actúan como estrategias diferentes para generar resúmenes según el `summary_type`.


### PR DESCRIPTION
Removed all references to premium users, including the `premium_only` decorator, premium user checks, and related database fields. This change simplifies user management by focusing only on normal users and administrators. Updated documentation and help messages to reflect these changes.